### PR TITLE
[add]rewardのグラフを表示させる

### DIFF
--- a/Battery-Control-By-Reinforcement-Learning/RL_env.py
+++ b/Battery-Control-By-Reinforcement-Learning/RL_env.py
@@ -3,9 +3,11 @@ import gym
 import warnings
 import numpy as np
 import math
+import matplotlib.pyplot as plt
 
 # internal modules
 from RL_dataframe_manager import Dataframe_Manager
+
 
 warnings.simplefilter('ignore')
 
@@ -45,12 +47,14 @@ class ESS_ModelEnv(gym.Env):
         self.state_idx = 0 # time_steps in all episodes (all episodes is a sum of time frames in train/test days 48*days)
         self.reward_total = 0 # 全episodeでの合計のreward
         self.reward_list = [] # 各stepでのreward
+        self.episode_rewards = []  # 各エピソードの報酬合計を保存するリスト
 
         # # Mode選択
         # self.mode = train    # train or test
 
     #### time_stepごとのactionの決定とrewardの計算を行う
     def step(self, action):
+
         # time_stepを一つ進める
         self.state_idx += 1
         ## rewardの計算
@@ -82,11 +86,17 @@ class ESS_ModelEnv(gym.Env):
         # state_idxは48コマ(1日)で割った余りが0になると、1日終了とする
         if self.state_idx % 48 == 0:
             done = True # Trueだと勝手にresetが走る
+            # 直近48コマの報酬の合計を計算しリストに追加
+            recent_reward = sum(self.reward_list[-48:])
+            self.episode_rewards.append(recent_reward)
+            info = {'episode_reward': recent_reward}  # 情報にエピソードの合計報酬を追加
+
         else:
-            done = False         
-        
-        # 付随情報をinfoに入れる
-        info = {}
+            done = False    
+             # 付随情報をinfoに入れる
+            info = {}     
+    
+       
         
         return observation, reward, done, info
     

--- a/Battery-Control-By-Reinforcement-Learning/RL_visualize.py
+++ b/Battery-Control-By-Reinforcement-Learning/RL_visualize.py
@@ -3,25 +3,14 @@
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from matplotlib.backends.backend_pdf import PdfPages
+import numpy as np
 
+from RL_env import ESS_ModelEnv
 
-
-Class RL_visualize:
-    def __init__(self):
-        self.steps = steps  # envからもらってくる
+class RL_visualize:
+    def __init__(self, episode, all_rewards):
+        self.steps = episode  # envからもらってくる
         self.all_rewards = all_rewards # envからもらってくる
-
-    if __name__ == "__main__" :
-        pp = PdfPages(pdf_name) # PDFの作成
-        graph_1 = self.descr_reward(self.steps, self.all_rewards)
-        graph_2 = self.descr_schedule(self.all_action_real, self.all_PV_out_time, self.all_energy_transfer, self.all_soc, mode = 0)
-        graph_3 = self.descr_schedule(self.all_action_real, self.all_PV_out_time, self.all_energy_transfer, self.all_soc, mode = 1)
-
-        pp.savefig(graph_1)
-        pp.savefig(graph_2)
-        pp.savefig(graph_3)
-
-        pp.close()
 
     # 充放電計画のグラフの描写
     def descr_schedule(self, action, PVout, energy_transfer, soc, mode):     #修正後のactionを引き渡す
@@ -132,13 +121,31 @@ Class RL_visualize:
         return fig
 
     # rewardのグラフの描写
-    def descr_reward(self, steps, reward):
+    def descr_reward(self, episode, reward):
         fig = plt.figure(figsize=(24, 14), dpi=80)
-        plt.plot(np.arange(steps), reward, label = "Reward")
+        plt.plot(np.arange(episode), reward, label = "Reward")
         plt.legend(prop={"size": 35})
         plt.xlabel("Episode", fontsize = 35)
         plt.ylabel("Reward", fontsize = 35)
         plt.tick_params(labelsize=35)
-        plt.close()
         
         return fig
+
+if __name__ == "__main__" :
+        env = ESS_ModelEnv()
+
+        all_rewards=env.episode_rewards
+        episode=len(all_rewards)
+        # クラスのインスタンス化
+        visualizer = RL_visualize(episode, all_rewards)
+        pp = PdfPages('RL_visualize.pdf') # PDFの作成
+        # グラフの描画
+        graph_1 = visualizer.descr_reward(episode, all_rewards)
+        graph_2 = visualizer.descr_schedule(all_action_real, all_PV_out_time, self.all_energy_transfer, self.all_soc, mode = 0)
+        graph_3 = visualizer.descr_schedule(all_action_real, all_PV_out_time, self.all_energy_transfer, self.all_soc, mode = 1)
+
+        pp.savefig(graph_1)
+        pp.savefig(graph_2)
+        pp.savefig(graph_3)
+
+        pp.close()


### PR DESCRIPTION
issue#78
・RL_env.py内で1episode終了時に48コマ分のreward合計値をリストに保存し、それをRL_visualize.pyで使用します
・RL_visualize.pyの他のグラフのエラーにより実行までは確認できていません